### PR TITLE
fix: Trapping the exit signal in `FsDriver`

### DIFF
--- a/.changeset/large-moles-lay.md
+++ b/.changeset/large-moles-lay.md
@@ -1,0 +1,5 @@
+---
+'storage-box': patch
+---
+
+fix: Trapping the exit signal in `FsDriver`


### PR DESCRIPTION
For some reason, the process was being terminated and the file was not being written. I couldn't reproduce the issue in this project's unit tests. Well, I decided to capture more of the exit events, and it seems to be working fine now.